### PR TITLE
add readme and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Gitter Chat
+    url: https://gitter.im/devfile/community
+    about: gitter community channel

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,30 @@
+---
+name: 🔧 Open an issue
+about: Report an issue or ask a question
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+
+Welcome! - We kindly ask you to:
+
+  1. Fill out the issue template below is you want to report an issue or ask a question. 
+  2. Use Gitter if you want to directly communicate with our developers.
+    See the Gitter community channel at: https://gitter.im/devfile/community
+
+Thanks for understanding and for contributing to the project!
+
+-->
+
+### Which stack/sample this issue is related to?
+
+### Issue description
+
+### Additional details
+<!--
+    Add any other context or screenshots about the issue.
+-->
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# support
+This repository is to track issues on stacks and samples stored within [devfile-samples](https://github.com/devfile-samples), and the following stacks hosted at https://registry.devfile.io:
+- java-maven
+- Java-springboot 
+- Python
+- Python-django
+
+
+## Support Information
+
+For reporting any issues or asking questions, please open an issue in this repo.
+
+To discuss with stack/sample maintainer: [Gitter Chat](https://gitter.im/devfile/community)


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

For https://github.com/devfile/api/issues/608

This PR adds repo description and stacks/samples support in readme, also adds issue template.