### PR TITLE
add more supported stacks in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 This repository is to track issues on stacks and samples stored within [devfile-samples](https://github.com/devfile-samples), and the following stacks hosted at https://registry.devfile.io:
+- go
 - java-maven
-- Java-springboot 
-- Python
-- Python-django
+- java-springboot 
+- nodejs-angular
+- nodejs-nextjs
+- nodejs-nuxtjs
+- nodejs-react
+- nodejs-svelte
+- nodejs-vue
+- php-laravel
+- python
+- python-django
 
 
 ## Support Information
 
-For reporting any issues or asking questions, please open an issue in this repo.
+For reporting any issues or asking questions, please [open an issue](https://github.com/devfile-samples/devfile-support/issues/new?assignees=&labels=&template=issue_template.md&title=) in this repository.
 
 To discuss with stack/sample maintainer: [Gitter Chat](https://gitter.im/devfile/community)


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

update the readme to include more stacks supported by devfile-services team. 